### PR TITLE
Bh1745 driver

### DIFF
--- a/code/ColorSensor.cpp
+++ b/code/ColorSensor.cpp
@@ -28,10 +28,16 @@ ColorSensor* ColorSensor::getInstance()
     return _instance;
 }
 
-
 void ColorSensor::Initialize()
 {
     bh1745nuc_init();
+
+    bh1745nuc_write_byte(BH1745NUC_INTERRUPT, 0x01);
+    bh1745nuc_write_byte(BH1745NUC_PERSISTENCE, 0x01);
+    bh1745nuc_write_byte(BH1745NUC_TH_LSB, 0x00);
+    bh1745nuc_write_byte(BH1745NUC_TH_MSB, 0x00);
+    bh1745nuc_write_byte(BH1745NUC_TL_LSB, 0xFF);
+    bh1745nuc_write_byte(BH1745NUC_TL_MSB, 0xFF);
 }
 
 void ColorSensor::getColor(uint16_t * r, uint16_t * g, uint16_t * b, uint16_t * c)

--- a/code/Controller.cpp
+++ b/code/Controller.cpp
@@ -20,6 +20,9 @@ Controller::Controller(void) {
     position = Position::getInstance(17, 27);
     lineSensor = LineSensor::getInstance(10, 9, 11);
 
+    colorSensor = ColorSensor::getInstance();
+    colorSensor->Initialize();
+    
     rangingSensor = RangingSensor::getInstance();
     rangingSensor->Initialize();
 
@@ -48,7 +51,11 @@ void Controller::changeDriveMode(Mode mode, int voltage_level) {
 }
 
 float Controller::getRanging(void) {
-    return rangingSensor->getRanging();
+  return rangingSensor->getRanging();
+}
+
+void Controller::getColorValue(uint16_t* red, uint16_t* green, uint16_t* blue, uint16_t* clear) {
+    colorSensor->getColor(red, green, blue, clear);
 }
 
 void Controller::getLineValue(bool* left, bool* center, bool* right){

--- a/code/Controller.h
+++ b/code/Controller.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include "CommonDefine.h"
+#include "ColorSensor.h"
 #include "RangingSensor.h"
 #include "TwinWheelDriver.h"
 #include "Position.h"
@@ -15,6 +16,7 @@ class Score;
 class Controller {
 private:
     TwinWheelDriver *twinWheelDriver;
+    ColorSensor *colorSensor;
     RangingSensor *rangingSensor;
     CNetMqtt netMqtt;
     LineSensor *lineSensor;
@@ -41,10 +43,12 @@ public:
 
     // LineSensor系
     void getLineValue(bool* left, bool* center, bool* right);
-   
+    
     // RangingSensor系
     float getRanging(void);
 
+    void getColorValue(uint16_t* red, uint16_t* green, uint16_t* blue, uint16_t* clear);
+    
     // Course系
     void getNextScoreTable(int nextScoreTable[4]);
     int subscrTopic(void);

--- a/code/Event.cpp
+++ b/code/Event.cpp
@@ -97,6 +97,8 @@ int Event::updateEvent() {
 
     float rangingDistance;
 
+    uint16_t red, green, blue, clear;
+    
     bool left, center, right;
 
     if (kbhit()) {
@@ -111,6 +113,7 @@ int Event::updateEvent() {
     absDistanceDiff = ABS_FLOAT(this->distanceOld - distance);
     absAngleDiff = ABS_FLOAT(this->angleOld - angle);
     controller->getLineValue(&left, &center, &right);
+    controller->getColorValue(&red, &green, &blue, &clear);
     rangingDistance = controller->getRanging();
     if(rangingDistance != this->rangingDistanceOld){
       this->event |= E_CHANGE_RANGING;
@@ -166,7 +169,8 @@ int Event::updateEvent() {
     //     this->event &= ~E_REACH;
     // }
 
-    printf("distance=%f, angle=%f, ranging=%f, line_left=%d, line_center=%d, line_right=%d\n", distance, angle, rangingDistance, left, center, right);
+    printf("distance=%f,angle=%f,ranging=%f,color_r=%d,color_g=%d,color_b=%d,line_l=%d,line_c=%d,line_r=%d\n",
+	   distance, angle, rangingDistance, red, green, blue, left, center, right);
     this->distanceOld = distance;
     this->angleOld = angle;
     this->rangingDistanceOld = rangingDistance;

--- a/code/bh1745nuc.c
+++ b/code/bh1745nuc.c
@@ -6,11 +6,10 @@
 #include <errno.h>
 
 #include "bh1745nuc.h"
-#include "bh1745nuc_reg.h"
 
 #include <stdio.h>
 
-#define BH1745NUC_DEVICE_ADDRESS 0x39
+#define BH1745NUC_DEVICE_ADDRESS 0x38
 
 static int fd;
 
@@ -46,6 +45,17 @@ int32_t bh1745nuc_init(void)
     return 0;
 }
 
+
+int32_t bh1745nuc_write_byte(uint8_t addr, uint8_t val)
+{
+    uint8_t data[2] = {0};
+
+    data[0] = addr;
+    data[1] = val;
+    write(fd, data, 2);
+
+    return 0;
+}
 
 int32_t bh1745nuc_get_val(uint16_t * r, uint16_t * g, uint16_t * b, uint16_t * c)
 {

--- a/code/bh1745nuc.h
+++ b/code/bh1745nuc.h
@@ -3,12 +3,16 @@
 
 #include <stdint.h>
 
+#include "bh1745nuc_reg.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int32_t bh1745nuc_init(void);
 
+int32_t bh1745nuc_write_byte(uint8_t addr, uint8_t val);
+  
 int32_t bh1745nuc_get_val(uint16_t * r, uint16_t * g, uint16_t * b, uint16_t * c);
 
 #ifdef __cplusplus

--- a/code/bh1745nuc_reg.h
+++ b/code/bh1745nuc_reg.h
@@ -14,5 +14,12 @@
 //BH1745NUC_CLEAR_DATA_LSB
 //BH1745NUC_CLEAR_DATA_MSB
 //:
+#define BH1745NUC_INTERRUPT         0x60
+#define BH1745NUC_PERSISTENCE       0x61
+#define BH1745NUC_TH_LSB            0x62
+#define BH1745NUC_TH_MSB            0x63
+#define BH1745NUC_TL_LSB            0x64
+#define BH1745NUC_TL_MSB            0x65
+#define BH1745NUC_MANUFACTURER_ID   0x92
 
 #endif // _BH1745NUC_REG_


### PR DESCRIPTION
・BH1745NUCドライバにレジスタ書込公開関数を追加（カラーセンサクラスでブレークアウト基板固有の機能：LED点灯制御を吸収するため）
・カラーセンサクラスの初期化メソッドにてPIMORONIブレークアウト基板のLED点灯を制御（INTピンの閾値を最低にしてラッチする動きのはず）
・イベントループにカラーセンサ値取得メソッド呼び出しを追加